### PR TITLE
Sender should be able to update its own memos

### DIFF
--- a/packages/hardhat/contracts/BuyMeACoffee.sol
+++ b/packages/hardhat/contracts/BuyMeACoffee.sol
@@ -115,7 +115,7 @@ contract BuyMeACoffee {
 
         Memo memory memo = memos[index];
 
-        if (memo.userAddress != msg.sender || msg.sender != owner) {
+        if (memo.userAddress != msg.sender && msg.sender != owner) {
             revert InvalidArguments("Operation not allowed");
         }
 


### PR DESCRIPTION
## Description

In BuyMeACoffee contract a sender couldn't update its own memos, it should de able to do it

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: netnose.eth
